### PR TITLE
set app from response

### DIFF
--- a/client.go
+++ b/client.go
@@ -162,6 +162,7 @@ func (c *Client) request(options *RequestOptions) (*Response, error) {
 		app := Application{}
 		err := json.Unmarshal(data, &app)
 		if err == nil {
+			resp.App = &app
 			resp.DeploymentId = app.Deployments[0].ID
 		} else {
 			fmt.Println("Error unmashaling data response")


### PR DESCRIPTION
The create app response entity is the application in Marathon's v2 API, this sets the response.App field with the unmarshaled application.
